### PR TITLE
Add refresh() method

### DIFF
--- a/src/Terbium/DbConfig/DbConfig.php
+++ b/src/Terbium/DbConfig/DbConfig.php
@@ -53,7 +53,15 @@ class DbConfig implements ConfigContract, ArrayAccess
 
         $this->items = $this->dbProvider->load();
     }
-
+    
+    
+    /**
+     * reload all items from DB
+     */
+    public function refresh()
+    {
+        $this->items = $this->dbProvider->load();
+    }
 
     /**
      * Save item into database and set to current config


### PR DESCRIPTION
Refresh() method - reload all items from DB. Needed if DbConfig is used in daemon, and instance of app needs to get refreshed DB settings.